### PR TITLE
Change npc from bolvar to king varian - quest 7496

### DIFF
--- a/modules/mod-progression-system/src/Bracket_60_2/sql/world/progression_60_2_onyxia.sql
+++ b/modules/mod-progression-system/src/Bracket_60_2/sql/world/progression_60_2_onyxia.sql
@@ -78,7 +78,7 @@ INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES
 
 DELETE FROM `creature_queststarter` WHERE `quest` = 7496;
 INSERT INTO `creature_queststarter` (`id`, `quest`) VALUES
-(1748, 7496);
+(29611, 7496);
 
 DELETE FROM `creature_questender` WHERE `quest` = 7491;
 INSERT INTO `creature_questender` (`id`, `quest`) VALUES


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Change the quest giver of quest 7496 (Celebrating Good Times) from Bolvar Fordragon to King Varian Wrynn

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- The Alliance cannot pick up the quest 7496 (Celebrating Good Times) after handing in 7495 (Victory for the Alliance)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Add or obtain the Head of Onxyia (18423)
2. Accept the quest
3. Teleport to StormwindKeep or run there
4. Hand in the quest 7495 (Victory for the Alliance)
5. Pick up the quest 7496 (Celebrating Good Times)

